### PR TITLE
Update rust-analyzer-compile.yml

### DIFF
--- a/.github/workflows/rust-analyzer-compile.yml
+++ b/.github/workflows/rust-analyzer-compile.yml
@@ -15,6 +15,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Get current time
+      uses: josStorer/get-current-time@v2
+      id: current-time
+      with:
+        format: DD-MM-YYYY
+        utcOffset: "+02:00"
     - name: Prepare
       run: |
         sudo apt-get update
@@ -31,4 +37,4 @@ jobs:
         artifacts: "rust-analyzer/target/armv7-unknown-linux-gnueabihf/release/rust-analyzer"
         token: ${{ secrets.GITHUB_TOKEN }}
         commit: main
-        tag: latest
+        tag: "${{ steps.current-time.outputs.time }}"


### PR DESCRIPTION
Added time-dependant tags so that builds don't fail anymore.